### PR TITLE
Clean up apt leftovers and flink tar.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,9 +18,9 @@ COPY finish-step.sh /
 ##Flink 0.10.1 Installation
 ###Download:
 
-RUN apt-get update \
-      && wget http://mirror.switch.ch/mirror/apache/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop27-scala_2.11.tgz \
+RUN   wget http://mirror.switch.ch/mirror/apache/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop27-scala_2.11.tgz \
       && tar -xvzf flink-0.10.1-bin-hadoop27-scala_2.11.tgz \
+      && rm flink-0.10.1-bin-hadoop27-scala_2.11.tgz \
       && mv flink-0.10.1 /usr/local/flink 
 
 ENV FLINK_HOME /usr/local/flink

--- a/template/maven/Dockerfile
+++ b/template/maven/Dockerfile
@@ -8,6 +8,8 @@ COPY template.sh /
 
 RUN apt-get update \
       && apt-get install -y maven \
+      && apt-get clean \ 
+      && rm -rf /var/lib/apt/lists/* \
       && chmod +x /template.sh \
       && update-java-alternatives -s java-1.8.0-openjdk-amd64 \
       && mkdir -p /app \


### PR DESCRIPTION
This removes unnecessary apt-get update, removes downloaded flink binary and cleans up after apt update and install of maven.
