### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: bash
+sudo: false
+script: 
+  - bash build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/big-data-europe/docker-flink.svg?branch=master)](https://travis-ci.org/big-data-europe/docker-flink)
+[![Twitter](https://img.shields.io/twitter/follow/BigData_Europe.svg?style=social)](https://twitter.com/BigData_Europe)
 # Flink docker
 
 Apache Flink docker images to:


### PR DESCRIPTION
This PR enables Travis CI and add badges for Build Status and Twitter. 

**Note**: The automatic build check (via Travis CI) is needed while checking the docker build (using [build.sh](https://github.com/big-data-europe/docker-flink/blob/master/build.sh) script) before we merge any contributions to the master and/or any other branch.

Best,